### PR TITLE
add c++11 option for error: ‘shared_ptr’ in namespace ‘std’ does not …

### DIFF
--- a/pr2_arm_kinematics/CMakeLists.txt
+++ b/pr2_arm_kinematics/CMakeLists.txt
@@ -3,6 +3,8 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(pr2_arm_kinematics)
 
+add_compile_options(-std=c++11)
+
 find_package(Boost REQUIRED thread)
 find_package(catkin REQUIRED COMPONENTS roscpp angles tf_conversions urdf geometry_msgs kdl_parser moveit_msgs moveit_core pluginlib cmake_modules)
 find_package(Eigen REQUIRED)


### PR DESCRIPTION
…name a template type typedef std::shared_ptr<Type> Name##Ptr; error