### PR TITLE
fix kinematics_plugin settings

### DIFF
--- a/pr2_arm_kinematics/package.xml
+++ b/pr2_arm_kinematics/package.xml
@@ -35,7 +35,7 @@
 
 <export>
     <cpp lflags="-Wl,-rpath,${prefix}/lib -L${prefix}/lib -lpr2_arm_kinematics_lib" cflags="-I${prefix}/include"/>
-    <kinematics_base plugin="${prefix}/kinematics_plugins.xml"/>
+    <moveit_core plugin="${prefix}/kinematics_plugins.xml"/>
 </export>
 
 </package>


### PR DESCRIPTION
without this fix, we'll get
```
[ INFO] [1573818459.038512756]: Loading robot model 'pr2'...
[ WARN] [1573818459.047898726]: The root link base_footprint has an inertia specified in the URDF, but KDL does not support a root link with an inertia.  As a workaround, you can add an extra dummy link to your URDF.
[ERROR] [1573818459.052289873]: The kinematics plugin (right_arm) failed to load. Error: According to the loaded plugin descriptions the class pr2_arm_kinematics/PR2ArmKinematicsPlugin with base class type kinematics::KinematicsBase does not exist. Declared types are  cached_ik_kinematics_plugin/CachedKDLKinematicsPlugin cached_ik_kinematics_plugin/CachedSrvKinematicsPlugin kdl_kinematics_plugin/KDLKinematicsPlugin lma_kinematics_plugin/LMAKinematicsPlugin nextage_left_arm_kinematics/IKFastKinematicsPlugin nextage_right_arm_kinematics/IKFastKinematicsPlugin srv_kinematics_plugin/SrvKinematicsPlugin trac_ik_kinematics_plugin/TRAC_IKKinematicsPlugin
[ERROR] [1573818459.052314890]: Kinematics solver could not be instantiated for joint group right_arm.
```